### PR TITLE
bug(copy-paste): preserve line breaks for pasting into word processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ class MyEditor extends Component {
 }
 ```
 
-`registerCopySource` will ensure the clipboard contains a full representation of the Draft.js content state on copy, while `handleDraftEditorPastedText` retrieves Draft.js content state from the clipboard. Voilà!
+`registerCopySource` will ensure the clipboard contains a full representation of the Draft.js content state on copy, while `handleDraftEditorPastedText` retrieves Draft.js content state from the clipboard. Voilà! This also changes the HTML clipboard content to be more semantic, with less styles copied to other word processors/editors.
 
 Relevant Draft.js issues:
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -9,8 +9,10 @@ const hasLibChanges =
   libModifiedFiles.filter((filepath) => !filepath.endsWith("test.js")).length >
   0;
 const hasLibTestChanges =
-  libModifiedFiles.filter((filepath) => filepath.endsWith("test.js")).length >
-  0;
+  libModifiedFiles.filter(
+    (filepath) =>
+      filepath.endsWith("test.js") || filepath.endsWith("test.js.snap"),
+  ).length > 0;
 const hasREADMEChanges = danger.git.modified_files.includes("README.md");
 
 const hasLabels = danger.github.issue.labels.length !== 0;

--- a/src/lib/api/__snapshots__/copypaste.test.js.snap
+++ b/src/lib/api/__snapshots__/copypaste.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`copypaste copy/cut listener works 1`] = `"<div data-draftjs-conductor-fragment=\\"{&quot;blocks&quot;:[{&quot;key&quot;:&quot;a&quot;,&quot;text&quot;:&quot;test&quot;,&quot;type&quot;:&quot;unstyled&quot;,&quot;depth&quot;:0,&quot;inlineStyleRanges&quot;:[],&quot;entityRanges&quot;:[],&quot;data&quot;:{}}],&quot;entityMap&quot;:{}}\\"><div></div></div>"`;
+exports[`copypaste copy/cut listener works 1`] = `"<div data-draftjs-conductor-fragment=\\"{&quot;blocks&quot;:[{&quot;key&quot;:&quot;a&quot;,&quot;text&quot;:&quot;test&quot;,&quot;type&quot;:&quot;unstyled&quot;,&quot;depth&quot;:0,&quot;inlineStyleRanges&quot;:[],&quot;entityRanges&quot;:[],&quot;data&quot;:{}}],&quot;entityMap&quot;:{}}\\" style=\\"white-space: pre-wrap;\\"><div></div></div>"`;

--- a/src/lib/api/copypaste.js
+++ b/src/lib/api/copypaste.js
@@ -36,6 +36,10 @@ const draftEditorCopyListener = (ref: ElementRef<Editor>, e: Object) => {
     // Modern browsers only support a single range.
     fragmentElt.appendChild(selection.getRangeAt(0).cloneContents());
     fragmentElt.setAttribute(FRAGMENT_ATTR, serialisedContent);
+    // We set the style property to replicate the browser's behavior of inline styles in rich text copy-paste.
+    // In Draft.js, this is important for line breaks to be interpreted correctly when pasted into another word processor.
+    // See https://github.com/facebook/draft-js/blob/a1f4593d8fa949954053e5d5840d33ce1d1082c6/src/component/base/DraftEditor.react.js#L328.
+    fragmentElt.setAttribute("style", "white-space: pre-wrap;");
 
     e.clipboardData.setData("text/plain", selection.toString());
     e.clipboardData.setData("text/html", fragmentElt.outerHTML);


### PR DESCRIPTION
Adds `white-space: pre-wrap;` to wrapper HTML like a browser would, so word processors (e.g. Google Docs) know that line breaks are semantic.
