### PR TITLE
Mark package as side-effects-free for Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "dist/draftjs-conductor.cjs.js",
   "module": "dist/draftjs-conductor.esm.js",
+  "sideEffects": false,
   "keywords": [
     "draftjs",
     "draft-js",


### PR DESCRIPTION
Adds the `sideEffects: false` hint for Webpack projects consuming this package https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free.