### PR TITLE
Docs improvements: additional issue this fixes, and word of warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The default Draft.js copy-paste handlers lose a lot of the formatting when copy-
 
 Relevant Draft.js issues:
 
+- [Ability to retain pasted custom entities - facebook/draft-js#380](https://github.com/facebook/draft-js/issues/380)
 - [Copy/paste between editors – facebook/draft-js#787](https://github.com/facebook/draft-js/issues/787)
 - [Extra newlines added to text pasted between two Draft editors – facebook/draft-js#1389](https://github.com/facebook/draft-js/issues/1389)
 - [Copy/paste between editors strips soft returns – facebook/draft-js#1154](https://github.com/facebook/draft-js/issues/1154)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Relevant Draft.js issues:
 - [Nested list styles above 4 levels are not retained when copy-pasting between Draft instances. – facebook/draft-js#1605 (comment)](https://github.com/facebook/draft-js/pull/1605#pullrequestreview-87340460)
 - [Merged `<p>` tags on paste – facebook/draft-js#523 (comment)](https://github.com/facebook/draft-js/issues/523#issuecomment-371098488)
 
-To make it _just work_:
+All of those problems can be fixed with this library, which overrides the `copy` event to transfer more of the editor’s content, and introduces a function to use with the Draft.js [`handlePastedText`](https://draftjs.org/docs/api-reference-editor#handlepastedtext) to retrieve the pasted content.
+
+**This will paste all copied content, even if the target editor might not support it.** To ensure only supported content is retained, use filters like [draftjs-filters](https://github.com/thibaudcolas/draftjs-filters).
+
+Here’s how to use the copy override, and the paste handler:
 
 ```js
 import {


### PR DESCRIPTION
This documents an additional Draft.js issue this library fixes, as well as the need for filtering of the paste (like https://github.com/thibaudcolas/draftjs-filters) does so the paste target editor does not contain content it cannot support.