### PR TITLE
Support copy-paste of text rendered by decorators (#12)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+npx danger local

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class MyEditor extends Component {
 
 `registerCopySource` will ensure the clipboard contains a full representation of the Draft.js content state on copy, while `handleDraftEditorPastedText` retrieves Draft.js content state from the clipboard. Voilà! This also changes the HTML clipboard content to be more semantic, with less styles copied to other word processors/editors.
 
-Note: IE11 isn’t supported, as it doesn't support storing HTML in the clipboard.
+Note: IE11 isn’t supported, as it doesn't support storing HTML in the clipboard, and we also use the [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) API.
 
 ## Contributing
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,6 +1,7 @@
 // @flow
 // flowlint untyped-import:off
 const { danger, message, warn, fail, schedule } = require("danger");
+const isLocal = !danger.github;
 
 const libModifiedFiles = danger.git.modified_files.filter(
   (path) => path.startsWith("src/lib") && path.endsWith("js"),
@@ -15,35 +16,37 @@ const hasLibTestChanges =
   ).length > 0;
 const hasREADMEChanges = danger.git.modified_files.includes("README.md");
 
-const hasLabels = danger.github.issue.labels.length !== 0;
-const isEnhancement =
-  danger.github.issue.labels.some((l) => l.name === "enhancement") ||
-  danger.github.pr.title.includes("feature");
-const isBug =
-  danger.github.issue.labels.some((l) => l.name === "bug") ||
-  danger.github.pr.title.includes("fix") ||
-  danger.github.pr.title.includes("bug");
+if (!isLocal) {
+  const hasLabels = danger.github.issue.labels.length !== 0;
+  const isEnhancement =
+    danger.github.issue.labels.some((l) => l.name === "enhancement") ||
+    danger.github.pr.title.includes("feature");
+  const isBug =
+    danger.github.issue.labels.some((l) => l.name === "bug") ||
+    danger.github.pr.title.includes("fix") ||
+    danger.github.pr.title.includes("bug");
 
-if (!hasLabels) {
-  message("What labels should we add to this PR?");
-}
+  if (!hasLabels) {
+    message("What labels should we add to this PR?");
+  }
 
-// Fails if the description is too short.
-if (!danger.github.pr.body || danger.github.pr.body.length < 10) {
-  fail(":grey_question: This pull request needs a description.");
-}
+  // Fails if the description is too short.
+  if (!danger.github.pr.body || danger.github.pr.body.length < 10) {
+    fail(":grey_question: This pull request needs a description.");
+  }
 
-if (hasLibChanges && !hasLibTestChanges && (isEnhancement || isBug)) {
-  message("This PR may require new test cases");
-}
+  if (hasLibChanges && !hasLibTestChanges && (isEnhancement || isBug)) {
+    message("This PR may require new test cases");
+  }
 
-// Warns if the PR title contains [WIP]
-const isWIP = danger.github.pr.title.includes("WIP");
-if (isWIP) {
-  const title = ":construction_worker: Work In Progress";
-  const idea =
-    "This PR appears to be a work in progress, and may not be ready to be merged yet.";
-  warn(`${title} - <i>${idea}</i>`);
+  // Warns if the PR title contains [WIP]
+  const isWIP = danger.github.pr.title.includes("WIP");
+  if (isWIP) {
+    const title = ":construction_worker: Work In Progress";
+    const idea =
+      "This PR appears to be a work in progress, and may not be ready to be merged yet.";
+    warn(`${title} - <i>${idea}</i>`);
+  }
 }
 
 if (hasLibChanges && !hasREADMEChanges) {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,6 +1,6 @@
 // @flow
 // flowlint untyped-import:off
-import { danger, message, warn, fail, schedule } from "danger";
+const { danger, message, warn, fail, schedule } = require("danger");
 
 const libModifiedFiles = danger.git.modified_files.filter(
   (path) => path.startsWith("src/lib") && path.endsWith("js"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -24124,9 +24124,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.1.tgz",
-      "integrity": "sha512-XXUITwIkGb3CPJ2hforHah/zTINRyie5006Jd2HKy2qz7snEJXl0KLfsJZW/wst9g6R2rFvqba3VpNYdu1hDcA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,15 +44,6 @@
             "ms": "^2.1.1"
           }
         },
-        "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -74,18 +65,29 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0",
+        "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -130,41 +132,71 @@
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
-      "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz",
-      "integrity": "sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.4.tgz",
+      "integrity": "sha512-UbBHIa2qeAGgyiNR9RszVF7bUHEdgS4JAUNT8SiqrAN6YJVxlOxeLr5pBzb5kan302dejJ9nla4RyKcR1XT6XA==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-member-expression-to-functions": "^7.0.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.0",
-        "@babel/helper-split-export-declaration": "^7.4.0"
+        "@babel/helper-replace-supers": "^7.4.4",
+        "@babel/helper-split-export-declaration": "^7.4.4"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
-      "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+      "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.0",
+        "@babel/types": "^7.4.4",
         "lodash": "^4.17.11"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -204,12 +236,31 @@
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
-      "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -231,19 +282,30 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
-      "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+      "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/template": "^7.2.2",
-        "@babel/types": "^7.2.2",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "lodash": "^4.17.11"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -268,9 +330,9 @@
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
-      "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+      "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
@@ -298,15 +360,34 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
-      "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+      "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.0.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-simple-access": {
@@ -320,12 +401,31 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-wrap-function": {
@@ -341,14 +441,33 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
-      "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0"
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "@babel/highlight": {
@@ -371,9 +490,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -419,9 +538,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-      "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+      "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -439,13 +558,13 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
-      "integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+      "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
         "regexpu-core": "^4.5.4"
       }
     },
@@ -540,9 +659,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
-      "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+      "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -560,9 +679,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
-      "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+      "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -578,18 +697,18 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
-      "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+      "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.0",
+        "@babel/helper-define-map": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/helper-replace-supers": "^7.4.4",
+        "@babel/helper-split-export-declaration": "^7.4.4",
         "globals": "^11.1.0"
       }
     },
@@ -603,22 +722,22 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
-      "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+      "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
-      "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+      "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.3",
+        "@babel/helper-regex": "^7.4.4",
         "regexpu-core": "^4.5.4"
       }
     },
@@ -662,18 +781,18 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
-      "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
-      "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -709,23 +828,23 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
-      "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+      "integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.4.3",
+        "@babel/helper-module-transforms": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
-      "integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+      "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
+        "@babel/helper-hoist-variables": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -740,18 +859,18 @@
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
-      "integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.4.tgz",
+      "integrity": "sha512-Ki+Y9nXBlKfhD+LXaRS7v95TtTGYRAf9Y1rTDiE75zf8YQz4GDaWRXosMfJBXxnk88mGFjWdCRIeqDbon7spYA==",
       "dev": true,
       "requires": {
         "regexp-tree": "^0.1.0"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
-      "integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+      "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -768,12 +887,12 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
-      "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.4.0",
+        "@babel/helper-call-delegate": "^7.4.4",
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -838,9 +957,9 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
-      "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.4.tgz",
+      "integrity": "sha512-Zz3w+pX1SI0KMIiqshFZkwnVGUhDZzpX2vtPzfJBKQQq8WsP/Xy9DNdELWivxcKOCX/Pywge4SiEaPaLtoDT4g==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.13.4"
@@ -904,9 +1023,9 @@
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
-      "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -923,9 +1042,9 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.0.tgz",
-      "integrity": "sha512-U7/+zKnRZg04ggM/Bm+xmu2B/PrwyDQTT/V89FXWYWNMxBDwSx56u6jtk9SEbfLFbZaEI72L+5LPvQjeZgFCrQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.4.tgz",
+      "integrity": "sha512-rwDvjaMTx09WC0rXGBRlYSSkEHOKRrecY6hEr3SVIPKII8DVWXtapNAfAyMC0dovuO+zYArcAuKeu3q9DNRfzA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -933,75 +1052,89 @@
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
-      "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+      "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.3",
+        "@babel/helper-regex": "^7.4.4",
         "regexpu-core": "^4.5.4"
       }
     },
     "@babel/polyfill": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
-      "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
       "dev": true,
       "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.11.1"
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-env": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
-      "integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.4.tgz",
+      "integrity": "sha512-FU1H+ACWqZZqfw1x2G1tgtSSYSfxJLkpaUQL37CenULFARDo+h4xJoVHzRoHbK+85ViLciuI7ME4WTIhFRBBlw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.4.0",
+        "@babel/plugin-transform-async-to-generator": "^7.4.4",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.4.0",
-        "@babel/plugin-transform-classes": "^7.4.3",
+        "@babel/plugin-transform-block-scoping": "^7.4.4",
+        "@babel/plugin-transform-classes": "^7.4.4",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.4.3",
-        "@babel/plugin-transform-dotall-regex": "^7.4.3",
+        "@babel/plugin-transform-destructuring": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/plugin-transform-duplicate-keys": "^7.2.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.4.3",
-        "@babel/plugin-transform-function-name": "^7.4.3",
+        "@babel/plugin-transform-for-of": "^7.4.4",
+        "@babel/plugin-transform-function-name": "^7.4.4",
         "@babel/plugin-transform-literals": "^7.2.0",
         "@babel/plugin-transform-member-expression-literals": "^7.2.0",
         "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.4.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
+        "@babel/plugin-transform-modules-systemjs": "^7.4.4",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
-        "@babel/plugin-transform-new-target": "^7.4.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.4",
+        "@babel/plugin-transform-new-target": "^7.4.4",
         "@babel/plugin-transform-object-super": "^7.2.0",
-        "@babel/plugin-transform-parameters": "^7.4.3",
+        "@babel/plugin-transform-parameters": "^7.4.4",
         "@babel/plugin-transform-property-literals": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.4.3",
+        "@babel/plugin-transform-regenerator": "^7.4.4",
         "@babel/plugin-transform-reserved-words": "^7.2.0",
         "@babel/plugin-transform-shorthand-properties": "^7.2.0",
         "@babel/plugin-transform-spread": "^7.2.0",
         "@babel/plugin-transform-sticky-regex": "^7.2.0",
-        "@babel/plugin-transform-template-literals": "^7.2.0",
+        "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.4.3",
-        "@babel/types": "^7.4.0",
+        "@babel/plugin-transform-unicode-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "browserslist": "^4.5.2",
         "core-js-compat": "^3.0.0",
         "invariant": "^2.2.2",
@@ -1009,6 +1142,23 @@
         "semver": "^5.5.0"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
         "semver": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -1058,33 +1208,63 @@
       }
     },
     "@babel/template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.0",
+        "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/types": "^7.4.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.11"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1511,6 +1691,72 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
       "integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==",
       "dev": true
+    },
+    "@octokit/endpoint": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.1.1.tgz",
+      "integrity": "sha512-kCv3ZyqFTWGYmvuU0TETzC4jPGzyLCJrjXp65kRe9DHyQULZak+dpwmEbT7M2rpdr/O2im8ivrPGT6J+2WsKNg==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "3.2.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.2.tgz",
+      "integrity": "sha512-lBH2hf2Yuh9XlmP3MSpn3jL9DyCGG+cuPXDRQiJMK42BwW6xFhwWmG1k6xWykcLM4GwZG/5fuwcqnQXYG0ZTSg==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^5.1.0",
+        "deprecation": "^1.0.1",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^2.0.1"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
+          "dev": true
+        }
+      }
     },
     "@octokit/rest": {
       "version": "15.12.1",
@@ -2862,18 +3108,18 @@
       },
       "dependencies": {
         "@babel/core": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
-          "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
+          "integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.0",
-            "@babel/helpers": "^7.4.3",
-            "@babel/parser": "^7.4.3",
-            "@babel/template": "^7.4.0",
-            "@babel/traverse": "^7.4.3",
-            "@babel/types": "^7.4.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helpers": "^7.4.4",
+            "@babel/parser": "^7.4.4",
+            "@babel/template": "^7.4.4",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4",
             "convert-source-map": "^1.1.0",
             "debug": "^4.1.0",
             "json5": "^2.1.0",
@@ -2883,6 +3129,17 @@
             "source-map": "^0.5.0"
           }
         },
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2890,15 +3147,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
           }
         },
         "lodash": {
@@ -3234,13 +3482,13 @@
       "dev": true
     },
     "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
       }
     },
     "acorn": {
@@ -3267,9 +3515,9 @@
       }
     },
     "acorn-globals": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.1.tgz",
-      "integrity": "sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+      "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -3901,11 +4149,12 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -3957,9 +4206,9 @@
       "dev": true
     },
     "async-each": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
-      "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
     "async-limiter": {
@@ -3978,6 +4227,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
       "dev": true
     },
     "autoprefixer": {
@@ -4032,9 +4287,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -4316,9 +4571,9 @@
       }
     },
     "babel-plugin-named-asset-import": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.1.tgz",
-      "integrity": "sha512-vzZlo+yEB5YHqI6CRRTDojeT43J3Wf3C/MVkZW5UlbSeIIVUYRKtxaFT2L/VTv9mbIyatCW39+9g/SZolvwRUQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz",
+      "integrity": "sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ==",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -4636,9 +4891,9 @@
       "dev": true
     },
     "bail": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
       "dev": true
     },
     "balanced-match": {
@@ -4971,14 +5226,14 @@
       }
     },
     "browserslist": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-      "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+      "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000955",
-        "electron-to-chromium": "^1.3.122",
-        "node-releases": "^1.1.13"
+        "caniuse-lite": "^1.0.30000963",
+        "electron-to-chromium": "^1.3.127",
+        "node-releases": "^1.1.17"
       }
     },
     "bser": {
@@ -5208,9 +5463,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000959",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000959.tgz",
-      "integrity": "sha512-6BvqmS0VLmY4sJCz6AbIJRQfcns8McDxi424y+3kmtisJeA9/5qslP+K8sqremDau7UU4WSsqdRP032JrqZY8Q==",
+      "version": "1.0.30000967",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz",
+      "integrity": "sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ==",
       "dev": true
     },
     "capture-exit": {
@@ -5245,9 +5500,9 @@
       "dev": true
     },
     "ccount": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+      "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
       "dev": true
     },
     "center-align": {
@@ -5355,14 +5610,14 @@
           }
         },
         "fsevents": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-          "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "^2.9.2",
-            "node-pre-gyp": "^0.10.0"
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
           },
           "dependencies": {
             "abbrev": {
@@ -5374,8 +5629,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5396,14 +5650,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5418,20 +5670,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5440,12 +5689,12 @@
               "optional": true
             },
             "debug": {
-              "version": "2.6.9",
+              "version": "4.1.1",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.1"
               }
             },
             "deep-extend": {
@@ -5548,8 +5797,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5561,7 +5809,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5576,7 +5823,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -5584,14 +5830,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5610,30 +5854,29 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
             },
             "ms": {
-              "version": "2.0.0",
+              "version": "2.1.1",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "needle": {
-              "version": "2.2.4",
+              "version": "2.3.0",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
-                "debug": "^2.1.2",
+                "debug": "^4.1.0",
                 "iconv-lite": "^0.4.4",
                 "sax": "^1.2.4"
               }
             },
             "node-pre-gyp": {
-              "version": "0.10.3",
+              "version": "0.12.0",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -5661,13 +5904,13 @@
               }
             },
             "npm-bundled": {
-              "version": "1.0.5",
+              "version": "1.0.6",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
-              "version": "1.2.0",
+              "version": "1.4.1",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -5691,8 +5934,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5704,7 +5946,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5790,8 +6031,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5806,7 +6046,7 @@
               "optional": true
             },
             "semver": {
-              "version": "5.6.0",
+              "version": "5.7.0",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -5827,7 +6067,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5847,7 +6086,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5891,14 +6129,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6177,9 +6413,9 @@
       }
     },
     "color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
-      "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
+      "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
       "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
@@ -6227,13 +6463,10 @@
       }
     },
     "comma-separated-tokens": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz",
-      "integrity": "sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==",
-      "dev": true,
-      "requires": {
-        "trim": "0.0.1"
-      }
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.6.tgz",
+      "integrity": "sha512-f20oA7jsrrmERTS70r3tmRSxR8IJV2MTN7qe6hzgX+3ARfXrdMJFvGWvWQK0xpcBurg9j9eO2MiqzZ8Y+/UPCA==",
+      "dev": true
     },
     "commander": {
       "version": "2.18.0",
@@ -6270,12 +6503,12 @@
       "dev": true
     },
     "compressible": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
-      "integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.38.0 < 2"
+        "mime-db": ">= 1.40.0 < 2"
       }
     },
     "compression": {
@@ -6329,9 +6562,9 @@
       }
     },
     "confusing-browser-globals": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.6.tgz",
-      "integrity": "sha512-GzyX86c2TvaagAOR+lHL2Yq4T4EnoBcnojZBcNbxVKSunxmGTnioXHR5Mo2ha/XnCoQw8eurvj6Ta+SwPEPkKg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
+      "integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
       "dev": true
     },
     "connect-history-api-fallback": {
@@ -6798,9 +7031,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -6879,9 +7112,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -6954,9 +7187,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -7048,9 +7281,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -7268,9 +7501,9 @@
           }
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -7371,9 +7604,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -7457,9 +7690,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -7548,65 +7781,438 @@
       "dev": true
     },
     "damerau-levenshtein": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
       "dev": true
     },
     "danger": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-4.0.2.tgz",
-      "integrity": "sha512-MIxtP84bnsy6VYy4AbNtzQktH9b48fTbZz6KTjOfZxlRmamoiAmatTVcTqGIMgOWcmUG4H+avF9tZvWfwMIYdQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-7.1.4.tgz",
+      "integrity": "sha512-Q6Qi7GZ58k2kyGbZkToGquM8ELtY9GR2CsfHeKGzIa77cRzaTMvn/x1W4FH3Vd0WPIASDV1yFp0xjvbK9sPcpg==",
       "dev": true,
       "requires": {
-        "@babel/polyfill": "^7.0.0",
-        "@octokit/rest": "^15.9.5",
+        "@babel/polyfill": "^7.2.5",
+        "@octokit/rest": "^16.14.1",
         "chalk": "^2.3.0",
-        "commander": "^2.13.0",
-        "debug": "^3.1.0",
+        "commander": "^2.18.0",
+        "debug": "^4.1.1",
         "get-stdin": "^6.0.0",
+        "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "jsome": "^2.3.25",
-        "json5": "^1.0.0",
+        "json5": "^2.1.0",
         "jsonpointer": "^4.0.1",
-        "jsonwebtoken": "^8.2.1",
+        "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
         "lodash.isobject": "^3.0.2",
         "lodash.keys": "^4.0.8",
+        "lodash.mapvalues": "^4.6.0",
+        "lodash.memoize": "^4.1.2",
+        "memfs-or-file-map-to-github-branch": "^1.1.0",
+        "micromatch": "^3.1.10",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "^2.1.2",
-        "p-limit": "^1.2.0",
-        "parse-diff": "^0.4.2",
-        "parse-git-config": "^2.0.2",
+        "node-fetch": "^2.3.0",
+        "override-require": "^1.1.1",
+        "p-limit": "^2.1.0",
+        "parse-diff": "^0.5.1",
+        "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
         "parse-link-header": "^1.0.1",
         "pinpoint": "^1.1.0",
         "readline-sync": "^1.4.9",
         "require-from-string": "^2.0.2",
-        "rfc6902": "^2.2.2",
-        "supports-hyperlinks": "^1.0.1",
-        "vm2": "^3.6.0",
-        "voca": "^1.4.0"
+        "rfc6902": "^3.0.1",
+        "supports-hyperlinks": "^1.0.1"
       },
       "dependencies": {
+        "@octokit/rest": {
+          "version": "16.25.3",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.25.3.tgz",
+          "integrity": "sha512-/6/Isn9pNoKUQwuWUaskxMC6kFxtXTHhzsgYbyirEQ3UvcLciHvPgtRTbuV3bbVf0x4+4WEfKaI9UzxmPQ3W3A==",
+          "dev": true,
+          "requires": {
+            "@octokit/request": "3.0.2",
+            "atob-lite": "^2.0.0",
+            "before-after-hook": "^1.4.0",
+            "btoa-lite": "^1.0.0",
+            "deprecation": "^1.0.1",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "lodash.uniq": "^4.5.0",
+            "octokit-pagination-methods": "^1.1.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^2.0.0",
+            "url-template": "^2.0.8"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "before-after-hook": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+          "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
         "get-stdin": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
           "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
           "dev": true
         },
-        "node-fetch": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
-        "vm2": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.6.3.tgz",
-          "integrity": "sha512-9sGC9T+R/afjDSVyG15ATUPzm5ZHzvIJvwkVmQ+4H2Cy55uDp0dXneXV4gXC7RMd2crWcL/awfdHjCsNSm+ufg==",
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         }
       }
@@ -7720,6 +8326,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
       "dev": true
     },
     "default-gateway": {
@@ -7892,6 +8504,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "deprecation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+      "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
       "dev": true
     },
     "des.js": {
@@ -8179,9 +8797,9 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -8200,9 +8818,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.124",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz",
-      "integrity": "sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==",
+      "version": "1.3.133",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz",
+      "integrity": "sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg==",
       "dev": true
     },
     "elliptic": {
@@ -8954,9 +9572,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "dev": true
     },
     "events": {
@@ -11007,9 +11625,9 @@
       }
     },
     "globals": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
     "globby": {
@@ -11294,9 +11912,9 @@
       }
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -12190,9 +12808,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
     },
     "is-absolute-url": {
@@ -13496,9 +14114,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -13532,12 +14150,12 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
-      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "dev": true,
       "requires": {
-        "jws": "^3.1.5",
+        "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -13545,13 +14163,20 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
-        "ms": "^2.1.1"
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
       }
@@ -13569,32 +14194,32 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+      "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3"
       }
     },
     "jwa": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "dev": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.10",
+        "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "dev": true,
       "requires": {
-        "jwa": "^1.1.5",
+        "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -13726,6 +14351,17 @@
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
         "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
       }
     },
     "locate-path": {
@@ -13800,6 +14436,12 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -13860,6 +14502,12 @@
       "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
       "dev": true
     },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -13894,6 +14542,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "lodash.snakecase": {
@@ -14187,6 +14841,12 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "memfs-or-file-map-to-github-branch": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.1.2.tgz",
+      "integrity": "sha512-D2JKK2DTuVYQqquBWco3K6UfSVyVwmd58dgNqh+TgxHOZdTmR8I130gjMbVCkemDl/EzqDA62417cJxKL3/FFA==",
+      "dev": true
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -14297,18 +14957,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
@@ -14578,9 +15238,9 @@
       }
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
     "neo-async": {
@@ -14708,9 +15368,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.14.tgz",
-      "integrity": "sha512-d58EpVZRhQE60kWiWUaaPlK9dyC4zg3ZoMcHcky2d4hDksyQj0rUozwInOl0C66mBsqo01Tuns8AvxnL5S7PKg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.18.tgz",
+      "integrity": "sha512-/mnVgm6u/8OwlIsoyRXtTI0RfQcxZoAZbdwyXap0EeWwcOpDDymyCHM2/aR9XKmHXrvizHoPAOs0pcbiJ6RUaA==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -17879,9 +18539,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz",
-      "integrity": "sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+      "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
       "dev": true
     },
     "oauth-sign": {
@@ -18050,6 +18710,12 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -18190,6 +18856,12 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "override-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
+      "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
+      "dev": true
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -18320,9 +18992,9 @@
       }
     },
     "parse-diff": {
-      "version": "0.4.2",
-      "resolved": "http://registry.npmjs.org/parse-diff/-/parse-diff-0.4.2.tgz",
-      "integrity": "sha512-YYQzII66NqysdPgDVxzbdwNXMv5Ww562JSZSXZ4RIPoolzD7yqA4crgD8swrs+JNcvjoZMKMiT4kGcLYvf6IoA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.5.1.tgz",
+      "integrity": "sha512-/qXjo9x/pFa5bVk/ZXaJD0yr3Tf3Yp6MWWMr4vnUmumDrE0yoE6YDH2A8vmcCD/Ko3tW2o0X+zGYh2zMLXshsg==",
       "dev": true
     },
     "parse-git-config": {
@@ -18398,9 +19070,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
     "pascalcase": {
@@ -18803,9 +19475,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -18880,9 +19552,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -18955,9 +19627,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19031,9 +19703,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19106,9 +19778,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19182,9 +19854,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19257,9 +19929,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19335,9 +20007,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19410,9 +20082,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19484,9 +20156,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19559,9 +20231,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19634,9 +20306,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19709,9 +20381,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19783,9 +20455,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19857,9 +20529,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -19931,9 +20603,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20005,9 +20677,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20080,9 +20752,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20155,9 +20827,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20229,9 +20901,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20303,9 +20975,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20377,9 +21049,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20451,9 +21123,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20525,9 +21197,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20600,9 +21272,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20675,9 +21347,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20751,9 +21423,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20838,9 +21510,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20912,9 +21584,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -20986,9 +21658,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21063,9 +21735,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21151,9 +21823,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21237,9 +21909,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21314,9 +21986,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21393,9 +22065,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21479,9 +22151,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21603,9 +22275,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21677,9 +22349,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21753,9 +22425,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21830,9 +22502,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21907,9 +22579,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -21983,9 +22655,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22059,9 +22731,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22135,9 +22807,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22212,9 +22884,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22287,9 +22959,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22363,9 +23035,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22437,9 +23109,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22511,9 +23183,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22586,9 +23258,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22696,9 +23368,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22771,9 +23443,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22848,9 +23520,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22925,9 +23597,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -22999,9 +23671,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -23073,9 +23745,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -23148,9 +23820,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -23223,9 +23895,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -23319,9 +23991,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -23395,9 +24067,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -23576,13 +24248,13 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
+        "ipaddr.js": "1.9.0"
       }
     },
     "prr": {
@@ -23770,9 +24442,9 @@
       }
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
     "raw-body": {
@@ -24095,9 +24767,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.4.tgz",
-      "integrity": "sha512-fp+U98OMZcnduQ+NSEiQa4s/XMsbp+5KlydmkbESOw4P69iWZ68ZMFM5a2BuE0FgqPBKApJyRuYHR95jM8lAmg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
+      "integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==",
       "dev": true
     },
     "react-is": {
@@ -24652,9 +25324,9 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz",
-      "integrity": "sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.6.tgz",
+      "integrity": "sha512-LFrA98Dw/heXqDojz7qKFdygZmFoiVlvE1Zp7Cq2cvF+ZA+03Gmhy0k0PQlsC1jvHPiTUSs+pDHEuSWv6+6D7w==",
       "dev": true
     },
     "regexpp": {
@@ -24990,9 +25662,9 @@
       "dev": true
     },
     "rfc6902": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-2.4.0.tgz",
-      "integrity": "sha512-Oof0+ZGIey7+U2kIU51Ao2YUjgkik6iFwyKNIRzNnl9DD/WnaxQnp21iUwBlkbqrRkxuE/DGPRroLzYjj/ngMA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-3.0.2.tgz",
+      "integrity": "sha512-Ky6zSlAL5HVu28/BQ+R8vgrKxgTKYBygww9D+TSms7Mylg+mSFdFVtGpHr+XZ8TFiAWslsqaK6qHbrl7XvYjWA==",
       "dev": true
     },
     "rgb-regex": {
@@ -25416,9 +26088,9 @@
       }
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -26251,9 +26923,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
-      "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
       "dev": true
     },
     "serve-index": {
@@ -26725,13 +27397,10 @@
       "dev": true
     },
     "space-separated-tokens": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz",
-      "integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
-      "dev": true,
-      "requires": {
-        "trim": "0.0.1"
-      }
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.3.tgz",
+      "integrity": "sha512-/M5RAdBuQlSDPNfA5ube+fkHbHyY08pMuADLmsAQURzo56w90r681oiOoz3o3ZQyWdSeNucpTFjL+Ggd5qui3w==",
+      "dev": true
     },
     "spawn-error-forwarder": {
       "version": "1.0.0",
@@ -27217,9 +27886,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -27294,9 +27963,9 @@
       }
     },
     "svgo": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.1.tgz",
-      "integrity": "sha512-Y1+LyT4/y1ms4/0yxPMSlvx6dIbgklE9w8CIOnfeoFGB74MEkq8inSfEr6NhocTaFbyYp0a1dvNgRKGRmEBlzA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+      "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -27306,7 +27975,7 @@
         "css-tree": "1.0.0-alpha.28",
         "css-url-regex": "^1.1.0",
         "csso": "^3.5.1",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
         "object.values": "^1.1.0",
         "sax": "~1.2.4",
@@ -27418,9 +28087,9 @@
       "dev": true
     },
     "table": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.3.3.tgz",
+      "integrity": "sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==",
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",
@@ -27729,12 +28398,6 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -27766,9 +28429,9 @@
       "dev": true
     },
     "ts-pnp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.0.1.tgz",
-      "integrity": "sha512-Zzg9XH0anaqhNSlDRibNC8Kp+B9KNM0uRIpLpGkGyrgRIttA7zZBhotTSEoEyuDrz3QW2LGtu2dxuk34HzIGnQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.2.tgz",
+      "integrity": "sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==",
       "dev": true
     },
     "tslib": {
@@ -27808,13 +28471,13 @@
       }
     },
     "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "~2.1.24"
       }
     },
     "typedarray": {
@@ -28164,12 +28827,12 @@
       }
     },
     "url-parse": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.6.tgz",
-      "integrity": "sha512-/B8AD9iQ01seoXmXf9z/MjLZQIdOoYl/+gvsQF6+mpnxaTfG9P7srYaiqaDMyKkR36XMXfhqSHss5MyFAO8lew==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "dev": true,
       "requires": {
-        "querystringify": "^2.0.0",
+        "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
     },
@@ -28245,9 +28908,9 @@
       "dev": true
     },
     "vendors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-      "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+      "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
       "dev": true
     },
     "verror": {
@@ -28327,12 +28990,6 @@
         "indexof": "0.0.1"
       }
     },
-    "voca": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/voca/-/voca-1.4.0.tgz",
-      "integrity": "sha512-8Xz4H3vhYRGbFupLtl6dHwMx0ojUcjt0HYkqZ9oBCfipd/5mD7Md58m2/dq7uPuZU/0T3Gb1m66KS9jn+I+14Q==",
-      "dev": true
-    },
     "w3c-hr-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
@@ -28382,9 +29039,9 @@
       }
     },
     "web-namespaces": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.2.tgz",
-      "integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
+      "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA==",
       "dev": true
     },
     "webidl-conversions": {
@@ -29323,9 +29980,9 @@
       }
     },
     "worker-farm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
         "errno": "~0.1.7"

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
   "dependencies": {},
   "peerDependencies": {
     "draft-js": "^0.10.5",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@semantic-release/exec": "^3.1.3",
     "@semantic-release/git": "^7.0.4",
     "core-js": "^2.5.7",
-    "danger": "^4.0.2",
+    "danger": "^7.1.4",
     "draft-js": "0.10.5",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,6 @@
     "dist/*.js"
   ],
   "browserslist": "> 1%, IE 11",
-  "babel": {
-    "presets": [
-      "env"
-    ]
-  },
   "devDependencies": {
     "@babel/plugin-transform-flow-comments": "^7.4.0",
     "@commitlint/cli": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "flow-bin": "^0.91.0",
     "immutable": "~3.7.6",
     "normalize.css": "^7.0.0",
-    "prettier": "^1.16.1",
+    "prettier": "^1.17.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-scripts": "^2.1.8",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,6 +5,7 @@ module.exports = {
   useTabs: false,
   semi: true,
   singleQuote: false,
+  quoteProps: "consistent",
   trailingComma: "all",
   bracketSpacing: true,
   arrowParens: "always",

--- a/src/demo/components/App.js
+++ b/src/demo/components/App.js
@@ -4,12 +4,197 @@ import "./App.css";
 
 import DemoEditor from "../components/DemoEditor";
 
+const copyPasteContent = {
+  blocks: [
+    {
+      key: "8qfte",
+      text: "Copy this content",
+      type: "header-two",
+    },
+    {
+      key: "6m80m",
+      text: " ",
+      type: "atomic",
+      entityRanges: [
+        {
+          offset: 0,
+          length: 1,
+          key: 0,
+        },
+      ],
+    },
+    {
+      key: "c0ala",
+      text: "",
+      type: "unstyled",
+    },
+    {
+      key: "7knr3",
+      text: "From here",
+      type: "header-three",
+    },
+    {
+      key: "er6ke",
+      text: "To the editor below!",
+      type: "unordered-list-item",
+    },
+    {
+      key: "47a3o",
+      text: " ",
+      type: "atomic",
+      entityRanges: [
+        {
+          offset: 0,
+          length: 1,
+          key: 1,
+        },
+      ],
+    },
+    {
+      key: "826u0",
+      text: "Numbered list",
+      type: "ordered-list-item",
+    },
+  ],
+  entityMap: {
+    "0": {
+      type: "HORIZONTAL_RULE",
+      mutability: "IMMUTABLE",
+      data: {},
+    },
+    "1": {
+      type: "SNIPPET",
+      mutability: "IMMUTABLE",
+      data: {
+        text: "Content of the snippet goes here",
+      },
+    },
+  },
+};
+
+const listNestingContent = {
+  blocks: [
+    {
+      key: "ako0c",
+      text: "Infinite",
+      type: "unordered-list-item",
+      depth: 0,
+    },
+    {
+      key: "adreo",
+      text: "Nested",
+      type: "unordered-list-item",
+      depth: 1,
+    },
+    {
+      key: "bm3ec",
+      text: "List",
+      type: "unordered-list-item",
+      depth: 2,
+    },
+    {
+      key: "aqg1s",
+      text: "Nesting",
+      type: "unordered-list-item",
+      depth: 3,
+    },
+    {
+      key: "4dns4",
+      text: "Styles",
+      type: "unordered-list-item",
+      depth: 4,
+    },
+    {
+      key: "5k6tv",
+      text: "Work",
+      type: "unordered-list-item",
+      depth: 5,
+    },
+    {
+      key: "9htu8",
+      text: "For",
+      type: "unordered-list-item",
+      depth: 6,
+    },
+    {
+      key: "at7om",
+      text: "As",
+      type: "unordered-list-item",
+      depth: 7,
+    },
+    {
+      key: "8fddl",
+      text: "Many",
+      type: "unordered-list-item",
+      depth: 8,
+    },
+    {
+      key: "2ja3i",
+      text: "Levels",
+      type: "unordered-list-item",
+      depth: 9,
+    },
+    {
+      key: "cv49i",
+      text: "As",
+      type: "unordered-list-item",
+      depth: 10,
+    },
+    {
+      key: "4aoq9",
+      text: "Configured",
+      type: "unordered-list-item",
+      depth: 11,
+    },
+    {
+      key: "d4hhk",
+      text: "Here",
+      type: "unordered-list-item",
+      depth: 12,
+    },
+    {
+      key: "bbeuk",
+      text: "Up",
+      type: "unordered-list-item",
+      depth: 13,
+    },
+    {
+      key: "6s9a8",
+      text: "To",
+      type: "unordered-list-item",
+      depth: 14,
+    },
+    {
+      key: "48sq1",
+      text: "15!",
+      type: "unordered-list-item",
+      depth: 15,
+    },
+  ],
+  entityMap: {},
+};
+
 class App extends Component<{}> {
   render() {
     return (
       <div className="App">
+        <h2>Idempotent copy-paste between editors</h2>
+        <p>
+          The default Draft.js copy-paste handlers lose a lot of the formatting
+          when copy-pasting between Draft.js editors. While this might be ok for
+          some use cases, sites with multiple editors on the same page need them
+          to reliably support copy-paste.
+        </p>
+        <DemoEditor extended={true} rawContentState={copyPasteContent} />
         <DemoEditor extended={false} />
-        <DemoEditor extended={true} />
+        <h2>Infinite list nesting</h2>
+        <p>
+          By default, Draft.js only provides support for 5 list levels for
+          bulleted and numbered lists. While this is often more than enough,
+          some editors need to go further. This provides infinite list nesting
+          styles.
+        </p>
+        <DemoEditor extended={false} rawContentState={listNestingContent} />
       </div>
     );
   }

--- a/src/demo/components/DemoEditor.js
+++ b/src/demo/components/DemoEditor.js
@@ -33,7 +33,7 @@ import "./DemoEditor.css";
 const NestingStyles = React.memo(ListNestingStyles);
 
 const BLOCKS = {
-  unstyled: "P",
+  "unstyled": "P",
   "unordered-list-item": "UL",
   "ordered-list-item": "OL",
   "header-one": "H1",
@@ -43,7 +43,7 @@ const BLOCKS = {
 };
 
 const BLOCKS_EXTENDED = {
-  unstyled: "P",
+  "unstyled": "P",
   "unordered-list-item": "UL",
   "ordered-list-item": "OL",
   "header-one": "H1",
@@ -52,7 +52,7 @@ const BLOCKS_EXTENDED = {
   "header-four": "H4",
   "header-five": "H5",
   "header-six": "H6",
-  blockquote: "❝",
+  "blockquote": "❝",
   "code-block": "{ }",
 };
 

--- a/src/demo/components/DemoEditor.js
+++ b/src/demo/components/DemoEditor.js
@@ -103,6 +103,7 @@ const ENTITIES = [
 const MAX_LIST_NESTING = 15;
 
 type Props = {
+  rawContentState: ?{},
   extended: boolean,
 };
 
@@ -120,9 +121,13 @@ class DemoEditor extends Component<Props, State> {
   /* :: editorRef: ?ElementRef<Editor>; */
   /* :: copySource: { unregister: () => void }; */
 
+  static defaultProps = {
+    rawContentState: null,
+  };
+
   constructor(props: Props) {
     super(props);
-    const { extended } = props;
+    const { rawContentState } = props;
 
     const decorator = new CompositeDecorator([
       {
@@ -131,11 +136,11 @@ class DemoEditor extends Component<Props, State> {
       },
     ]);
 
-    const save = window.sessionStorage.getItem("extended");
     let editorState;
 
-    if (extended && save) {
-      const content = convertFromRaw(JSON.parse(save));
+    if (rawContentState) {
+      // $FlowFixMe
+      const content = convertFromRaw(rawContentState);
       // $FlowFixMe
       editorState = EditorState.createWithContent(content, decorator);
     } else {
@@ -170,11 +175,6 @@ class DemoEditor extends Component<Props, State> {
   /* :: onChange: (nextState: EditorState) => void; */
   onChange(nextState: EditorState) {
     this.setState({ editorState: nextState });
-
-    window.sessionStorage.setItem(
-      `content`,
-      JSON.stringify(convertToRaw(nextState.getCurrentContent())),
-    );
   }
 
   /* :: toggleStyle: (type: string, e: Event) => void; */

--- a/src/demo/components/DemoEditor.js
+++ b/src/demo/components/DemoEditor.js
@@ -24,6 +24,7 @@ import SentryBoundary from "./SentryBoundary";
 import Highlight from "./Highlight";
 import Link, { linkStrategy } from "./Link";
 import Image from "./Image";
+import Snippet from "./Snippet";
 
 import DraftUtils from "../utils/DraftUtils";
 
@@ -84,6 +85,12 @@ const ENTITIES = [
     whitelist: {
       src: "^http",
     },
+  },
+  {
+    type: "SNIPPET",
+    label: "🌱",
+    attributes: ["text"],
+    whitelist: {},
   },
   {
     type: "HORIZONTAL_RULE",
@@ -186,8 +193,8 @@ class DemoEditor extends Component<Props, State> {
     e.preventDefault();
   }
 
-  /* :: toggleEntity: (type: DraftEntityType | "HORIZONTAL_RULE") => void; */
-  toggleEntity(type: DraftEntityType | "HORIZONTAL_RULE") {
+  /* :: toggleEntity: (type: DraftEntityType | "HORIZONTAL_RULE" | "SNIPPET") => void; */
+  toggleEntity(type: DraftEntityType | "HORIZONTAL_RULE" | "SNIPPET") {
     const { editorState } = this.state;
     let content = editorState.getCurrentContent();
 
@@ -195,6 +202,15 @@ class DemoEditor extends Component<Props, State> {
       content = content.createEntity(type, "IMMUTABLE", {
         src:
           "https://thibaudcolas.github.io/draftjs-conductor/wysiwyg-magic-wand.png",
+      });
+      const entityKey = content.getLastCreatedEntityKey();
+      this.onChange(
+        AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, " "),
+      );
+    } else if (type === "SNIPPET") {
+      // $FlowFixMe
+      content = content.createEntity(type, "IMMUTABLE", {
+        text: "Content of the snippet goes here",
       });
       const entityKey = content.getLastCreatedEntityKey();
       this.onChange(
@@ -239,6 +255,13 @@ class DemoEditor extends Component<Props, State> {
     if (entity.getType() === "HORIZONTAL_RULE") {
       return {
         component: () => <hr />,
+        editable: false,
+      };
+    }
+
+    if (entity.getType() === "SNIPPET") {
+      return {
+        component: Snippet,
         editable: false,
       };
     }

--- a/src/demo/components/DemoEditor.test.js
+++ b/src/demo/components/DemoEditor.test.js
@@ -7,8 +7,6 @@ import DraftUtils from "../utils/DraftUtils";
 
 describe("DemoEditor", () => {
   beforeEach(() => {
-    jest.spyOn(Storage.prototype, "getItem");
-    jest.spyOn(Storage.prototype, "setItem");
     jest.spyOn(RichUtils, "toggleInlineStyle");
     jest.spyOn(RichUtils, "toggleBlockType");
     jest.spyOn(RichUtils, "toggleLink");
@@ -42,29 +40,17 @@ describe("DemoEditor", () => {
       ).toMatchSnapshot();
     });
 
-    it("save feature", () => {
-      global.sessionStorage.getItem.mockReturnValue(
-        JSON.stringify({
-          entityMap: {},
-          blocks: [
-            {
-              key: "a",
-              text: "test",
-            },
-          ],
-        }),
-      );
-
+    it("can take predefined content", () => {
       expect(
-        mount(<DemoEditor extended />)
-          .state("editorState")
-          .getCurrentContent()
-          .getBlockMap()
-          .map((b) => b.getText())
-          .toJS(),
-      ).toEqual({
-        a: "test",
-      });
+        mount(
+          <DemoEditor
+            rawContentState={{
+              blocks: [{ key: "a", text: "Test" }],
+              entityMap: {},
+            }}
+          />,
+        ).find(".EditorToolbar"),
+      ).toMatchSnapshot();
     });
   });
 
@@ -112,6 +98,14 @@ describe("DemoEditor", () => {
       expect(AtomicBlockUtils.insertAtomicBlock).toHaveBeenCalled();
     });
 
+    it("SNIPPET", () => {
+      mount(<DemoEditor extended={false} />)
+        .instance()
+        .toggleEntity("SNIPPET");
+
+      expect(AtomicBlockUtils.insertAtomicBlock).toHaveBeenCalled();
+    });
+
     it("HORIZONTAL_RULE", () => {
       mount(<DemoEditor extended={false} />)
         .instance()
@@ -155,34 +149,36 @@ describe("DemoEditor", () => {
     });
 
     it("HORIZONTAL_RULE", () => {
-      window.sessionStorage.getItem = jest.fn(() =>
-        JSON.stringify({
-          entityMap: {
-            "3": {
-              type: "HORIZONTAL_RULE",
-              data: {},
+      const Component = mount(
+        <DemoEditor
+          extended={true}
+          rawContentState={{
+            entityMap: {
+              "5": {
+                type: "HORIZONTAL_RULE",
+                data: {},
+              },
             },
-          },
-          blocks: [
-            {
-              type: "atomic",
-              text: " ",
-              entityRanges: [
-                {
-                  key: 3,
-                  offset: 0,
-                  length: 1,
-                },
-              ],
-            },
-          ],
-        }),
-      );
-      const Component = mount(<DemoEditor extended={true} />)
+            blocks: [
+              {
+                type: "atomic",
+                text: " ",
+                entityRanges: [
+                  {
+                    key: 5,
+                    offset: 0,
+                    length: 1,
+                  },
+                ],
+              },
+            ],
+          }}
+        />,
+      )
         .instance()
         .blockRenderer({
           getType: () => "atomic",
-          getEntityAt: () => "3",
+          getEntityAt: () => "5",
         }).component;
       expect(Component()).toEqual(<hr />);
     });
@@ -193,6 +189,42 @@ describe("DemoEditor", () => {
           entityMap: {
             "1": {
               type: "IMAGE",
+              data: {
+                src: "example.png",
+              },
+            },
+          },
+          blocks: [
+            {
+              type: "atomic",
+              text: " ",
+              entityRanges: [
+                {
+                  key: 1,
+                  offset: 0,
+                  length: 1,
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      const Component = mount(<DemoEditor extended={true} />)
+        .instance()
+        .blockRenderer({
+          getType: () => "atomic",
+          getEntityAt: () => "1",
+        }).component;
+      expect(<Component />).toMatchSnapshot();
+    });
+
+    it("SNIPPET", () => {
+      window.sessionStorage.getItem = jest.fn(() =>
+        JSON.stringify({
+          entityMap: {
+            "1": {
+              type: "SNIPPET",
               data: {
                 src: "example.png",
               },

--- a/src/demo/components/Image.js
+++ b/src/demo/components/Image.js
@@ -14,7 +14,12 @@ const Image = ({
     ? contentState.getEntity(entityKey).getData().src
     : "/404";
 
-  return <img src={src} alt="" width="256" />;
+  return (
+    <div>
+      <p>Image:</p>
+      <img src={src} alt="" width="256" />
+    </div>
+  );
 };
 
 export default Image;

--- a/src/demo/components/Snippet.css
+++ b/src/demo/components/Snippet.css
@@ -1,0 +1,16 @@
+.Snippet {
+  font-size: 20px;
+  border-radius: 6px;
+  border: 1px solid gray;
+  background-color: whitesmoke;
+  padding: 40px;
+}
+
+.Snippet__text {
+  font-size: 16px;
+  font-weight: bold;
+  border-radius: 6px;
+  background-color: lightgrey;
+  margin-top: 10px;
+  padding: 40px;
+}

--- a/src/demo/components/Snippet.js
+++ b/src/demo/components/Snippet.js
@@ -1,0 +1,28 @@
+// @flow
+import React from "react";
+import { ContentBlock, ContentState } from "draft-js";
+
+import "./Snippet.css";
+
+const Snippet = ({
+  block,
+  contentState,
+}: {
+  block: ContentBlock,
+  contentState: ContentState,
+}) => {
+  const entityKey = block.getEntityAt(0);
+  const text = entityKey
+    ? contentState.getEntity(entityKey).getData().text
+    : "Placeholder";
+  return (
+    <div className="Snippet" contentEditable={false}>
+      This is a snippet block:
+      <div className="Snippet__text" contentEditable={false}>
+        {text}
+      </div>
+    </div>
+  );
+};
+
+export default Snippet;

--- a/src/demo/components/Snippet.test.js
+++ b/src/demo/components/Snippet.test.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { convertFromRaw } from "draft-js";
+
+import Snippet from "./Snippet";
+
+describe("Snippet", () => {
+  it("renders", () => {
+    const content = convertFromRaw({
+      entityMap: {
+        "0": {
+          type: "SNIPPET",
+          data: {
+            text: "This is a snippet",
+          },
+        },
+      },
+      blocks: [
+        {
+          key: "a",
+          text: " ",
+          entityRanges: [
+            {
+              offset: 0,
+              length: 1,
+              key: 0,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(
+      shallow(
+        <Snippet contentState={content} block={content.getFirstBlock()} />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("no entity", () => {
+    const content = convertFromRaw({
+      entityMap: {},
+      blocks: [
+        {
+          key: "a",
+          text: " ",
+        },
+      ],
+    });
+
+    expect(
+      shallow(
+        <Snippet contentState={content} block={content.getFirstBlock()} />,
+      ),
+    ).toMatchSnapshot();
+  });
+});

--- a/src/demo/components/__snapshots__/App.test.js.snap
+++ b/src/demo/components/__snapshots__/App.test.js.snap
@@ -4,11 +4,199 @@ exports[`App renders 1`] = `
 <div
   className="App"
 >
-  <DemoEditor
-    extended={false}
-  />
+  <h2>
+    Idempotent copy-paste between editors
+  </h2>
+  <p>
+    The default Draft.js copy-paste handlers lose a lot of the formatting when copy-pasting between Draft.js editors. While this might be ok for some use cases, sites with multiple editors on the same page need them to reliably support copy-paste.
+  </p>
   <DemoEditor
     extended={true}
+    rawContentState={
+      Object {
+        "blocks": Array [
+          Object {
+            "key": "8qfte",
+            "text": "Copy this content",
+            "type": "header-two",
+          },
+          Object {
+            "entityRanges": Array [
+              Object {
+                "key": 0,
+                "length": 1,
+                "offset": 0,
+              },
+            ],
+            "key": "6m80m",
+            "text": " ",
+            "type": "atomic",
+          },
+          Object {
+            "key": "c0ala",
+            "text": "",
+            "type": "unstyled",
+          },
+          Object {
+            "key": "7knr3",
+            "text": "From here",
+            "type": "header-three",
+          },
+          Object {
+            "key": "er6ke",
+            "text": "To the editor below!",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "entityRanges": Array [
+              Object {
+                "key": 1,
+                "length": 1,
+                "offset": 0,
+              },
+            ],
+            "key": "47a3o",
+            "text": " ",
+            "type": "atomic",
+          },
+          Object {
+            "key": "826u0",
+            "text": "Numbered list",
+            "type": "ordered-list-item",
+          },
+        ],
+        "entityMap": Object {
+          "0": Object {
+            "data": Object {},
+            "mutability": "IMMUTABLE",
+            "type": "HORIZONTAL_RULE",
+          },
+          "1": Object {
+            "data": Object {
+              "text": "Content of the snippet goes here",
+            },
+            "mutability": "IMMUTABLE",
+            "type": "SNIPPET",
+          },
+        },
+      }
+    }
+  />
+  <DemoEditor
+    extended={false}
+    rawContentState={null}
+  />
+  <h2>
+    Infinite list nesting
+  </h2>
+  <p>
+    By default, Draft.js only provides support for 5 list levels for bulleted and numbered lists. While this is often more than enough, some editors need to go further. This provides infinite list nesting styles.
+  </p>
+  <DemoEditor
+    extended={false}
+    rawContentState={
+      Object {
+        "blocks": Array [
+          Object {
+            "depth": 0,
+            "key": "ako0c",
+            "text": "Infinite",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 1,
+            "key": "adreo",
+            "text": "Nested",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 2,
+            "key": "bm3ec",
+            "text": "List",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 3,
+            "key": "aqg1s",
+            "text": "Nesting",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 4,
+            "key": "4dns4",
+            "text": "Styles",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 5,
+            "key": "5k6tv",
+            "text": "Work",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 6,
+            "key": "9htu8",
+            "text": "For",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 7,
+            "key": "at7om",
+            "text": "As",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 8,
+            "key": "8fddl",
+            "text": "Many",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 9,
+            "key": "2ja3i",
+            "text": "Levels",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 10,
+            "key": "cv49i",
+            "text": "As",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 11,
+            "key": "4aoq9",
+            "text": "Configured",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 12,
+            "key": "d4hhk",
+            "text": "Here",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 13,
+            "key": "bbeuk",
+            "text": "Up",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 14,
+            "key": "6s9a8",
+            "text": "To",
+            "type": "unordered-list-item",
+          },
+          Object {
+            "depth": 15,
+            "key": "48sq1",
+            "text": "15!",
+            "type": "unordered-list-item",
+          },
+        ],
+        "entityMap": Object {},
+      }
+    }
   />
 </div>
 `;

--- a/src/demo/components/__snapshots__/DemoEditor.test.js.snap
+++ b/src/demo/components/__snapshots__/DemoEditor.test.js.snap
@@ -1,5 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DemoEditor #extended can take predefined content 1`] = `
+<div
+  className="EditorToolbar"
+>
+  <button
+    key="BOLD"
+    onMouseDown={[Function]}
+  >
+    B
+  </button>
+  <button
+    key="ITALIC"
+    onMouseDown={[Function]}
+  >
+    I
+  </button>
+  <button
+    key="unstyled"
+    onMouseDown={[Function]}
+  >
+    P
+  </button>
+  <button
+    key="unordered-list-item"
+    onMouseDown={[Function]}
+  >
+    UL
+  </button>
+  <button
+    key="ordered-list-item"
+    onMouseDown={[Function]}
+  >
+    OL
+  </button>
+  <button
+    key="header-one"
+    onMouseDown={[Function]}
+  >
+    H1
+  </button>
+  <button
+    key="header-two"
+    onMouseDown={[Function]}
+  >
+    H2
+  </button>
+  <button
+    key="header-three"
+    onMouseDown={[Function]}
+  >
+    H3
+  </button>
+  <button
+    key="code-block"
+    onMouseDown={[Function]}
+  >
+    { }
+  </button>
+  <button
+    key="LINK"
+    onMouseDown={[Function]}
+  >
+    🔗
+  </button>
+  <button
+    key="IMAGE"
+    onMouseDown={[Function]}
+  >
+    📷
+  </button>
+  <button
+    key="SNIPPET"
+    onMouseDown={[Function]}
+  >
+    🌱
+  </button>
+  <button
+    key="HORIZONTAL_RULE"
+    onMouseDown={[Function]}
+  >
+    HR
+  </button>
+  <button
+    onMouseDown={[Function]}
+  >
+    BR
+  </button>
+  <button
+    onMouseDown={[Function]}
+  >
+    📖
+  </button>
+</div>
+`;
+
 exports[`DemoEditor #extended works 1`] = `
 <div
   className="EditorToolbar"
@@ -138,6 +233,8 @@ exports[`DemoEditor #extended works 1`] = `
 `;
 
 exports[`DemoEditor blockRenderer IMAGE 1`] = `<Image />`;
+
+exports[`DemoEditor blockRenderer SNIPPET 1`] = `<Image />`;
 
 exports[`DemoEditor renders 1`] = `
 <div

--- a/src/demo/components/__snapshots__/DemoEditor.test.js.snap
+++ b/src/demo/components/__snapshots__/DemoEditor.test.js.snap
@@ -113,6 +113,12 @@ exports[`DemoEditor #extended works 1`] = `
     📷
   </button>
   <button
+    key="SNIPPET"
+    onMouseDown={[Function]}
+  >
+    🌱
+  </button>
+  <button
     key="HORIZONTAL_RULE"
     onMouseDown={[Function]}
   >
@@ -202,6 +208,12 @@ exports[`DemoEditor renders 1`] = `
     onMouseDown={[Function]}
   >
     📷
+  </button>
+  <button
+    key="SNIPPET"
+    onMouseDown={[Function]}
+  >
+    🌱
   </button>
   <button
     key="HORIZONTAL_RULE"

--- a/src/demo/components/__snapshots__/Image.test.js.snap
+++ b/src/demo/components/__snapshots__/Image.test.js.snap
@@ -1,17 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Image no entity 1`] = `
-<img
-  alt=""
-  src="/404"
-  width="256"
-/>
+<div>
+  <p>
+    Image:
+  </p>
+  <img
+    alt=""
+    src="/404"
+    width="256"
+  />
+</div>
 `;
 
 exports[`Image renders 1`] = `
-<img
-  alt=""
-  src="/example.png"
-  width="256"
-/>
+<div>
+  <p>
+    Image:
+  </p>
+  <img
+    alt=""
+    src="/example.png"
+    width="256"
+  />
+</div>
 `;

--- a/src/demo/components/__snapshots__/Snippet.test.js.snap
+++ b/src/demo/components/__snapshots__/Snippet.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Snippet no entity 1`] = `
+<div
+  className="Snippet"
+  contentEditable={false}
+>
+  This is a snippet block:
+  <div
+    className="Snippet__text"
+    contentEditable={false}
+  >
+    Placeholder
+  </div>
+</div>
+`;
+
+exports[`Snippet renders 1`] = `
+<div
+  className="Snippet"
+  contentEditable={false}
+>
+  This is a snippet block:
+  <div
+    className="Snippet__text"
+    contentEditable={false}
+  >
+    This is a snippet
+  </div>
+</div>
+`;

--- a/src/lib/api/copypaste.js
+++ b/src/lib/api/copypaste.js
@@ -34,7 +34,14 @@ export const getSelectedContent = (
     selectionState,
   );
 
-  return fragment;
+  // If the selection contains no content (according to Draft.js), use the default browser behavior.
+  // This happens when selecting text that's within contenteditable=false blocks in Draft.js.
+  // See https://github.com/thibaudcolas/draftjs-conductor/issues/12.
+  const isEmpty = fragment.every((block) => {
+    return block.getText().length === 0;
+  });
+
+  return isEmpty ? null : fragment;
 };
 
 /**

--- a/src/lib/api/copypaste.js
+++ b/src/lib/api/copypaste.js
@@ -27,6 +27,11 @@ const draftEditorCopyListener = (
     clipboardData: DataTransfer,
   },
 ) => {
+  // Completely skip event handling if clipboardData is not supported (IE11 is out).
+  if (!e.clipboardData) {
+    return;
+  }
+
   const selection = window.getSelection();
   // Get clipboard content from the selection like Draft.js would.
   const editorState = ref._latestEditorState;
@@ -38,8 +43,8 @@ const draftEditorCopyListener = (
     selectionState,
   );
 
-  // Override the default behavior if there is a selection, and content, and clipboardData is supported (IE11 is out).
-  if (selection.rangeCount > 0 && fragment && e.clipboardData) {
+  // Override the default behavior if there is a selection, and content.
+  if (selection.rangeCount > 0 && fragment) {
     const content = ContentState.createFromBlockArray(fragment.toArray());
     const serialisedContent = JSON.stringify(convertToRaw(content));
 

--- a/src/lib/api/copypaste.test.js
+++ b/src/lib/api/copypaste.test.js
@@ -172,6 +172,216 @@ describe("copypaste", () => {
       const event = dispatchEvent(editor, "copy", () => {});
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
+
+    it("supports copy-pasting from decorators content", () => {
+      const editor = document.createElement("div");
+
+      const content = {
+        blocks: [
+          {
+            key: "a",
+            type: "unstyled",
+            text: "",
+          },
+        ],
+        entityMap: {},
+      };
+
+      registerCopySource({
+        editor,
+        _latestEditorState: EditorState.createWithContent(
+          convertFromRaw(content),
+        ),
+      });
+
+      const contents = document.createElement("div");
+      contents.setAttribute("data-contents", "true");
+      const decorator = document.createElement("div");
+      decorator.setAttribute("contenteditable", "false");
+      contents.appendChild(decorator);
+      const anchorNode = document.createElement("div");
+      decorator.appendChild(anchorNode);
+      const focusNode = document.createElement("div");
+      anchorNode.appendChild(focusNode);
+
+      window.getSelection = getSelection({
+        rangeCount: 1,
+        anchorNode,
+        focusNode,
+      });
+
+      const event = dispatchEvent(editor, "copy", () => {});
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("supports copy-pasting from decorators content #2", () => {
+      const editor = document.createElement("div");
+
+      const content = {
+        blocks: [
+          {
+            key: "a",
+            type: "unstyled",
+            text: "",
+          },
+        ],
+        entityMap: {},
+      };
+
+      registerCopySource({
+        editor,
+        _latestEditorState: EditorState.createWithContent(
+          convertFromRaw(content),
+        ),
+      });
+
+      const contents = document.createElement("div");
+      contents.setAttribute("data-contents", "true");
+      const focusDecorator = document.createElement("div");
+      focusDecorator.setAttribute("contenteditable", "false");
+      contents.appendChild(focusDecorator);
+      const anchorDecorator = document.createElement("div");
+      anchorDecorator.setAttribute("contenteditable", "false");
+      contents.appendChild(anchorDecorator);
+      const anchorNode = document.createElement("div");
+      const focusNode = document.createElement("div");
+      anchorDecorator.appendChild(anchorNode);
+      focusDecorator.appendChild(focusNode);
+      focusDecorator.appendChild(anchorDecorator);
+
+      window.getSelection = getSelection({
+        rangeCount: 1,
+        anchorNode,
+        focusNode,
+      });
+
+      const event = dispatchEvent(editor, "copy", () => {});
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("supports pasting from text nodes only", () => {
+      const editor = document.createElement("div");
+
+      const content = {
+        blocks: [
+          {
+            key: "a",
+            type: "unstyled",
+            text: "",
+          },
+        ],
+        entityMap: {},
+      };
+
+      registerCopySource({
+        editor,
+        _latestEditorState: EditorState.createWithContent(
+          convertFromRaw(content),
+        ),
+      });
+
+      const contents = document.createElement("div");
+      contents.setAttribute("data-contents", "true");
+      const decorator = document.createElement("div");
+      decorator.setAttribute("contenteditable", "false");
+      contents.appendChild(decorator);
+      const anchorParent = document.createElement("div");
+      decorator.appendChild(anchorParent);
+      const anchorNode = document.createTextNode("this is text");
+      anchorParent.appendChild(anchorNode);
+      const focusNode = document.createTextNode("this is text");
+      anchorParent.appendChild(focusNode);
+
+      window.getSelection = getSelection({
+        rangeCount: 1,
+        anchorNode,
+        focusNode,
+      });
+
+      const event = dispatchEvent(editor, "copy", () => {});
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  it("checks whether anchor node is indeed in a decorator", () => {
+    const editor = document.createElement("div");
+
+    const content = {
+      blocks: [
+        {
+          key: "a",
+          type: "unstyled",
+          text: "",
+        },
+      ],
+      entityMap: {},
+    };
+
+    registerCopySource({
+      editor,
+      _latestEditorState: EditorState.createWithContent(
+        convertFromRaw(content),
+      ),
+    });
+
+    const contents = document.createElement("div");
+    contents.setAttribute("data-contents", "true");
+    const decorator = document.createElement("div");
+    decorator.setAttribute("contenteditable", "false");
+    contents.appendChild(decorator);
+    const anchorNode = document.createElement("div");
+    decorator.appendChild(anchorNode);
+    const focusNode = document.createElement("div");
+    // focusNode.appendChild(anchorNode);
+
+    window.getSelection = getSelection({
+      rangeCount: 1,
+      anchorNode,
+      focusNode,
+    });
+
+    const event = dispatchEvent(editor, "copy", () => {});
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("checks whether focus node is indeed in a decorator", () => {
+    const editor = document.createElement("div");
+
+    const content = {
+      blocks: [
+        {
+          key: "a",
+          type: "unstyled",
+          text: "",
+        },
+      ],
+      entityMap: {},
+    };
+
+    registerCopySource({
+      editor,
+      _latestEditorState: EditorState.createWithContent(
+        convertFromRaw(content),
+      ),
+    });
+
+    const contents = document.createElement("div");
+    contents.setAttribute("data-contents", "true");
+    const decorator = document.createElement("div");
+    decorator.setAttribute("contenteditable", "false");
+    contents.appendChild(decorator);
+    const anchorNode = document.createElement("div");
+    const focusNode = document.createElement("div");
+    focusNode.appendChild(anchorNode);
+
+    window.getSelection = getSelection({
+      rangeCount: 1,
+      anchorNode,
+      focusNode,
+    });
+
+    const event = dispatchEvent(editor, "copy", () => {});
+    expect(event.preventDefault).not.toHaveBeenCalled();
   });
 
   describe("handleDraftEditorPastedText", () => {

--- a/src/lib/api/copypaste.test.js
+++ b/src/lib/api/copypaste.test.js
@@ -145,6 +145,33 @@ describe("copypaste", () => {
         }
       });
     });
+
+    it("uses the default copy-paste behavior if content is empty", () => {
+      const editor = document.createElement("div");
+
+      const content = {
+        blocks: [
+          {
+            key: "a",
+            type: "unstyled",
+            text: "",
+          },
+        ],
+        entityMap: {},
+      };
+
+      registerCopySource({
+        editor,
+        _latestEditorState: EditorState.createWithContent(
+          convertFromRaw(content),
+        ),
+      });
+
+      window.getSelection = getSelection({ rangeCount: 1 });
+
+      const event = dispatchEvent(editor, "copy", () => {});
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
   });
 
   describe("handleDraftEditorPastedText", () => {

--- a/src/lib/api/copypaste.test.js
+++ b/src/lib/api/copypaste.test.js
@@ -23,13 +23,21 @@ describe("copypaste", () => {
       });
 
       window.getSelection = jest.fn(() => ({}));
-      editor.dispatchEvent(new Event("copy"));
+      editor.dispatchEvent(
+        Object.assign(new Event("copy"), {
+          clipboardData: {},
+        }),
+      );
       expect(window.getSelection).toHaveBeenCalled();
 
       copySource.unregister();
 
       window.getSelection = jest.fn(() => ({}));
-      editor.dispatchEvent(new Event("cut"));
+      editor.dispatchEvent(
+        Object.assign(new Event("cut"), {
+          clipboardData: {},
+        }),
+      );
       expect(window.getSelection).not.toHaveBeenCalled();
     });
 
@@ -42,13 +50,21 @@ describe("copypaste", () => {
       });
 
       window.getSelection = jest.fn(() => ({}));
-      editor.dispatchEvent(new Event("cut"));
+      editor.dispatchEvent(
+        Object.assign(new Event("cut"), {
+          clipboardData: {},
+        }),
+      );
       expect(window.getSelection).toHaveBeenCalled();
 
       copySource.unregister();
 
       window.getSelection = jest.fn(() => ({}));
-      editor.dispatchEvent(new Event("cut"));
+      editor.dispatchEvent(
+        Object.assign(new Event("cut"), {
+          clipboardData: {},
+        }),
+      );
       expect(window.getSelection).not.toHaveBeenCalled();
     });
   });

--- a/src/lib/components/ListNestingStyles.js
+++ b/src/lib/components/ListNestingStyles.js
@@ -41,7 +41,7 @@ export const generateListNestingStyles = (
 
 /**
  * Dynamically generates the right list nesting styles.
- * Pure component - will only re-render when `max` changes (eg. never).
+ * Can be wrapped as a pure component - to re-render only when `max` changes (eg. never).
  */
 export const ListNestingStyles = (props: { max: number }) => {
   const { max } = props;


### PR DESCRIPTION
Fixes #12. This makes copy-paste work as expected when the selection is fully within the decorator, when it's fully over the whole decorator, and in-between.