### PR TITLE
Add new API methods: data conversion helpers from Draftail

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Check out the [online demo](https://thibaudcolas.github.io/draftjs-conductor)!
 
 - [Infinite list nesting](#infinite-list-nesting)
 - [Idempotent copy-paste between editors](#idempotent-copy-paste-between-editors)
+- [Editor state data conversion helpers](#editor-state-data-conversion-helpers)
 
 ---
 
@@ -129,6 +130,32 @@ class MyEditor extends Component {
 `registerCopySource` will ensure the clipboard contains a full representation of the Draft.js content state on copy, while `handleDraftEditorPastedText` retrieves Draft.js content state from the clipboard. Voilà! This also changes the HTML clipboard content to be more semantic, with less styles copied to other word processors/editors.
 
 Note: IE11 isn’t supported, as it doesn't support storing HTML in the clipboard, and we also use the [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) API.
+
+### Editor state data conversion helpers
+
+Draft.js has its own data conversion helpers, [`convertFromRaw`](https://draftjs.org/docs/api-reference-data-conversion#convertfromraw) and [`convertToRaw`](https://draftjs.org/docs/api-reference-data-conversion#converttoraw), which work really well, but aren’t providing that good of an API when initialising or persisting the content of an editor.
+
+We provide two helper methods to simplify the initialisation and serialisation of content. **`createEditorStateFromRaw`** combines [`EditorState.createWithContent`](https://draftjs.org/docs/api-reference-editor-state#createwithcontent), [`EditorState.createEmpty`](https://draftjs.org/docs/api-reference-editor-state#createempty) and [`convertFromRaw`](https://draftjs.org/docs/api-reference-data-conversion#convertfromraw) as a single method:
+
+```js
+import { createEditorStateFromRaw } from "draftjs-conductor";
+
+// Initialise with `null` if there’s no preexisting state.
+const editorState = createEditorStateFromRaw(null);
+// Initialise with the raw content state otherwise
+const editorState = createEditorStateFromRaw({ entityMap: {}, blocks: [] });
+// Optionally use a decorator, like with Draft.js APIs.
+const editorState = createEditorStateFromRaw(null, decorator);
+```
+
+To save content, **`serialiseEditorStateToRaw`** combines [`convertToRaw`](https://draftjs.org/docs/api-reference-data-conversion#converttoraw) with checks for empty content – so empty content is saved as `null`, rather than a single text block with empty text as would be the case otherwise.
+
+```js
+import { serialiseEditorStateToRaw } from "draftjs-conductor";
+
+// Content will be `null` if there’s no textual content, or RawDraftContentState otherwise.
+const content = serialiseEditorStateToRaw(editorState);
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "start": "react-scripts start",
     "build": "CI=true react-scripts build && rollup -c",
     "test": "npm run test:coverage -s",
-    "test:coverage": "react-scripts test --env=jsdom --coverage",
+    "test:coverage": "CI=true react-scripts test --env=jsdom --coverage",
     "test:watch": "react-scripts test --env=jsdom",
     "report:coverage": "open coverage/lcov-report/index.html",
     "report:build": "source-map-explorer --html 'build/static/js/*.js' > build/source-map-explorer.html && open build/source-map-explorer.html",

--- a/src/demo/components/DemoEditor.js
+++ b/src/demo/components/DemoEditor.js
@@ -4,20 +4,20 @@ import {
   Editor,
   EditorState,
   RichUtils,
-  convertToRaw,
   CompositeDecorator,
   AtomicBlockUtils,
   ContentBlock,
-  convertFromRaw,
 } from "draft-js";
-import type { DraftBlockType } from "draft-js/lib/DraftBlockType.js.flow";
-import type { DraftEntityType } from "draft-js/lib/DraftEntityType.js.flow";
+import type { DraftBlockType } from "draft-js/lib/DraftBlockType";
+import type { DraftEntityType } from "draft-js/lib/DraftEntityType";
 
 import {
   ListNestingStyles,
   blockDepthStyleFn,
   registerCopySource,
   handleDraftEditorPastedText,
+  createEditorStateFromRaw,
+  serialiseEditorStateToRaw,
 } from "../../lib/index";
 
 import SentryBoundary from "./SentryBoundary";
@@ -136,20 +136,9 @@ class DemoEditor extends Component<Props, State> {
       },
     ]);
 
-    let editorState;
-
-    if (rawContentState) {
-      // $FlowFixMe
-      const content = convertFromRaw(rawContentState);
-      // $FlowFixMe
-      editorState = EditorState.createWithContent(content, decorator);
-    } else {
-      // $FlowFixMe
-      editorState = EditorState.createEmpty(decorator);
-    }
-
     this.state = {
-      editorState: editorState,
+      // $FlowFixMe Unclear why the decorator API disagrees with itself.
+      editorState: createEditorStateFromRaw(rawContentState, decorator),
       readOnly: false,
     };
 
@@ -367,7 +356,7 @@ class DemoEditor extends Component<Props, State> {
           </summary>
           <Highlight
             value={JSON.stringify(
-              convertToRaw(editorState.getCurrentContent()),
+              serialiseEditorStateToRaw(editorState),
               null,
               2,
             )}

--- a/src/lib/api/conversion.js
+++ b/src/lib/api/conversion.js
@@ -1,0 +1,45 @@
+// @flow
+import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
+import type { RawDraftContentState } from "draft-js/lib/RawDraftContentState";
+import type { DraftDecoratorType } from "draft-js/lib/DraftDecoratorType";
+
+const EMPTY_CONTENT_STATE = null;
+
+/**
+ * Creates a new EditorState from a RawDraftContentState, or an empty editor state by
+ * passing `null`. Optionally takes a decorator.
+ */
+export const createEditorStateFromRaw = (
+  rawContentState: ?RawDraftContentState,
+  decorator?: ?DraftDecoratorType,
+) => {
+  let editorState;
+
+  if (rawContentState) {
+    const contentState = convertFromRaw(rawContentState);
+    editorState = EditorState.createWithContent(contentState, decorator);
+  } else {
+    editorState = EditorState.createEmpty(decorator);
+  }
+
+  return editorState;
+};
+
+/**
+ * Serialises the editorState using `convertToRaw`, but returns `null` if
+ * the editor content is empty (no text, entities, styles).
+ */
+export const serialiseEditorStateToRaw = (editorState: EditorState) => {
+  const contentState = editorState.getCurrentContent();
+  const rawContentState = convertToRaw(contentState);
+
+  const isEmpty = rawContentState.blocks.every((block) => {
+    const isEmptyBlock =
+      block.text.trim().length === 0 &&
+      (!block.entityRanges || block.entityRanges.length === 0) &&
+      (!block.inlineStyleRanges || block.inlineStyleRanges.length === 0);
+    return isEmptyBlock;
+  });
+
+  return isEmpty ? EMPTY_CONTENT_STATE : rawContentState;
+};

--- a/src/lib/api/conversion.test.js
+++ b/src/lib/api/conversion.test.js
@@ -1,0 +1,92 @@
+import {
+  EditorState,
+  convertFromRaw,
+  convertToRaw,
+  CompositeDecorator,
+} from "draft-js";
+import {
+  createEditorStateFromRaw,
+  serialiseEditorStateToRaw,
+} from "./conversion";
+
+describe("#createEditorStateFromRaw", () => {
+  it("creates state from real content", () => {
+    const state = createEditorStateFromRaw({
+      entityMap: {},
+      blocks: [
+        { text: "Hello, World!", type: "unstyled" },
+        { text: "This is a title", type: "header-two" },
+      ],
+    });
+    const result = convertToRaw(state.getCurrentContent());
+    expect(state).toBeInstanceOf(EditorState);
+    expect(result.blocks.length).toEqual(2);
+    expect(result.blocks[0].text).toEqual("Hello, World!");
+  });
+
+  it("creates empty state from empty content", () => {
+    const state = createEditorStateFromRaw(null);
+    const result = convertToRaw(state.getCurrentContent());
+    expect(state).toBeInstanceOf(EditorState);
+    expect(result.blocks.length).toEqual(1);
+    expect(result.blocks[0].text).toEqual("");
+  });
+
+  it("takes a decorator", () => {
+    const decorator = new CompositeDecorator([
+      { strategy: () => {}, component: () => {} },
+    ]);
+    const state = createEditorStateFromRaw(null, decorator);
+    expect(state.getDecorator()).toBe(decorator);
+  });
+});
+
+describe("#serialiseEditorStateToRaw", () => {
+  it("keeps real content", () => {
+    const stubContent = {
+      entityMap: {},
+      blocks: [
+        {
+          key: "1dcqo",
+          text: "Hello, World!",
+          type: "unstyled",
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [],
+          data: {},
+        },
+        {
+          key: "dmtba",
+          text: "This is a title",
+          type: "header-two",
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [],
+          data: {},
+        },
+      ],
+    };
+    const state = createEditorStateFromRaw(stubContent);
+    expect(serialiseEditorStateToRaw(state)).toEqual(stubContent);
+  });
+
+  it("discards empty content", () => {
+    const state = createEditorStateFromRaw(null);
+    expect(serialiseEditorStateToRaw(state)).toBeNull();
+  });
+
+  it("discards content with only empty text", () => {
+    const editorState = EditorState.createWithContent(
+      convertFromRaw({
+        entityMap: {},
+        blocks: [
+          {
+            key: "a",
+            text: "",
+          },
+        ],
+      }),
+    );
+    expect(serialiseEditorStateToRaw(editorState)).toBeNull();
+  });
+});

--- a/src/lib/components/ListNestingStyles.js
+++ b/src/lib/components/ListNestingStyles.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 
-import type { BlockNode } from "draft-js/lib/BlockNode.js.flow";
+import type { BlockNode } from "draft-js/lib/BlockNode";
 
 // Default maximum block depth supported by Draft.js CSS.
 export const DRAFT_DEFAULT_MAX_DEPTH = 4;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -12,3 +12,8 @@ export {
   registerCopySource,
   handleDraftEditorPastedText,
 } from "./api/copypaste";
+
+export {
+  createEditorStateFromRaw,
+  serialiseEditorStateToRaw,
+} from "./api/conversion";

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -6,6 +6,8 @@ import {
   blockDepthStyleFn,
   registerCopySource,
   handleDraftEditorPastedText,
+  createEditorStateFromRaw,
+  serialiseEditorStateToRaw,
 } from "./index";
 
 const pkg = require("../../package.json");
@@ -31,4 +33,10 @@ describe(pkg.name, () => {
 
   it("handleDraftEditorPastedText", () =>
     expect(handleDraftEditorPastedText).toBeDefined());
+
+  it("createEditorStateFromRaw", () =>
+    expect(createEditorStateFromRaw).toBeDefined());
+
+  it("serialiseEditorStateToRaw", () =>
+    expect(serialiseEditorStateToRaw).toBeDefined());
 });


### PR DESCRIPTION
`createEditorStateFromRaw` simplifies creating an editor state from raw content. `serialiseEditorStateToRaw` uses `convertToRaw`, but has a special check to return `null` for empty content.

Those methods were originally defined in [Draftail](https://www.draftail.org), I’d like to make them reusable so it makes sense to move them here.