### PR TITLE
Add support for Draft.js v0.11.0

### DIFF
--- a/.githooks/pre-commit.8.test.sh
+++ b/.githooks/pre-commit.8.test.sh
@@ -4,5 +4,6 @@ set -e
 
 if [ -n "$JS_STAGED" ] || [ -n "$SNAPSHOT_STAGED" ];
 then
-  npm run test:coverage -s
+  DRAFTJS_VERSION=0.10.5 npm run test:coverage -s
+  DRAFTJS_VERSION=0.11.2 npm run test:coverage -s
 fi

--- a/.githooks/pre-commit.8.test.sh
+++ b/.githooks/pre-commit.8.test.sh
@@ -4,6 +4,6 @@ set -e
 
 if [ -n "$JS_STAGED" ] || [ -n "$SNAPSHOT_STAGED" ];
 then
-  DRAFTJS_VERSION=0.10.5 npm run test:coverage -s
-  DRAFTJS_VERSION=0.11.2 npm run test:coverage -s
+  DRAFTJS_VERSION=0.10 npm run test -s
+  DRAFTJS_VERSION=0.11 npm run test -s
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+version: ~> 1.0
+dist: bionic
 language: node_js
 install:
   - npm ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,12 @@ deploy:
     github_token: "$PAGES_GITHUB_API_TOKEN"
     on:
       branch: master
+      condition: "$DRAFTJS_VERSION = 0.10"
   - provider: script
     skip_cleanup: true
     script: npx semantic-release
     on:
-      branch: master
+      condition: "$DRAFTJS_VERSION = 0.10"
 notifications:
   email: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ install:
   - npm ci
 jobs:
   include:
-    - env: DRAFTJS_VERSION=0.10.5
-    - env: DRAFTJS_VERSION=0.11.2
+    - env: DRAFTJS_VERSION=0.10
+    - env: DRAFTJS_VERSION=0.11
 script:
   # Test Git hooks in CI, to make sure script upgrades do not break them.
   - npm run prepare

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 language: node_js
 install:
   - npm ci
+jobs:
+  include:
+    - env: DRAFTJS_VERSION=0.10.5
+    - env: DRAFTJS_VERSION=0.11.2
 script:
   # Test Git hooks in CI, to make sure script upgrades do not break them.
   - npm run prepare

--- a/package-lock.json
+++ b/package-lock.json
@@ -8216,6 +8216,41 @@
         "object-assign": "^4.1.0"
       }
     },
+    "draft-js-11": {
+      "version": "npm:draft-js@0.11.4",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.4.tgz",
+      "integrity": "sha512-BLZ59s0vkDj/zI8UPo9Nit/hPsl11ztDejxDCQlVbvEXJSWrTXqO6ZYgdw3hXLtuojq/URqq3wTrpnb3dvzvLA==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^1.0.0",
+        "immutable": "~3.7.4",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.21",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+          "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+          "dev": true
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -9899,6 +9934,12 @@
           "dev": true
         }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "coveralls": "3.0.9",
     "danger": "9.2.10",
     "draft-js": "0.10.5",
+    "draft-js-11": "npm:draft-js@^0.11.4",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.4.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "draft-js": "^0.10.5",
+    "draft-js": "^0.10.5 || ^0.11.0",
     "react": "^16.0.0"
   },
   "scripts": {

--- a/src/lib/api/copypaste.test.js
+++ b/src/lib/api/copypaste.test.js
@@ -7,6 +7,12 @@ jest.mock("draft-js/lib/getContentStateFragment", () => (content) =>
   content.getBlockMap(),
 );
 
+jest.mock("draft-js-11/lib/generateRandomKey", () => () => "a");
+jest.mock("draft-js-11/lib/getDraftEditorSelection", () => () => ({}));
+jest.mock("draft-js-11/lib/getContentStateFragment", () => (content) =>
+  content.getBlockMap(),
+);
+
 const dispatchEvent = (editor, type, setData) => {
   const event = Object.assign(new Event(type), {
     clipboardData: { setData },

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -8,10 +8,10 @@ expect.addSnapshotSerializer(createSerializer({ mode: "deep" }));
 
 jest.mock("draft-js", () => {
   const packages = {
-    "0.10.5": "draft-js",
-    "0.11.2": "draft-js-11",
+    "0.10": "draft-js",
+    "0.11": "draft-js-11",
   };
-  const version = process.env.DRAFTJS_VERSION || "0.10.5";
+  const version = process.env.DRAFTJS_VERSION || "0.10";
 
   // Require the original module.
   const originalModule = jest.requireActual(packages[version]);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,3 +5,19 @@ import { createSerializer } from "enzyme-to-json";
 configure({ adapter: new Adapter() });
 
 expect.addSnapshotSerializer(createSerializer({ mode: "deep" }));
+
+jest.mock("draft-js", () => {
+  const packages = {
+    "0.10.5": "draft-js",
+    "0.11.2": "draft-js-11",
+  };
+  const version = process.env.DRAFTJS_VERSION || "0.10.5";
+
+  // Require the original module.
+  const originalModule = jest.requireActual(packages[version]);
+
+  return {
+    __esModule: true,
+    ...originalModule,
+  };
+});


### PR DESCRIPTION
This updates the project’s test suite to run both with Draft.js 0.10.5 and 0.11.4. It should make it easy to improve support for new versions and address deprecations without compromising support for 0.10.5 for now.

This uses npm 6.9.0+’s support for module aliases:

```sh
npm install --save-dev draft-js-11@npm:draft-js@0.11.4
```