### PR TITLE
feat(api): onDraftEditorCopy, onDraftEditorCut for draft-js@0.11

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,8 +5,9 @@
 .*/node_modules/draft-js/lib/DraftEditorLeaf.react.js.flow
 .*/node_modules/draft-js/lib/DraftEditorDragHandler.js.flow
 .*/node_modules/draft-js/lib/DraftEditor.react.js.flow
+.*/node_modules/draft-js/lib/DraftEditor.react.js.flow
 .*/node_modules/config-chain
-.*/node_modules/fbjs/lib/emptyFunction.js.flow
+.*/node_modules/fbjs/lib/editOnPaste.js.flow
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 
 [include]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,12 +3,14 @@ import pkg from "./package.json";
 
 const BANNER = `// @flow`;
 
-export default [
+const config = [
   {
     input: "src/lib/index.js",
     external: [
       "draft-js/lib/getDraftEditorSelection",
       "draft-js/lib/getContentStateFragment",
+      "draft-js/lib/editOnCopy",
+      "draft-js/lib/editOnCut",
     ].concat(Object.keys(pkg.peerDependencies)),
     output: [
       { file: pkg.main, format: "cjs" },
@@ -34,3 +36,5 @@ export default [
     ],
   },
 ];
+
+export default config;

--- a/src/demo/components/DemoEditor.js
+++ b/src/demo/components/DemoEditor.js
@@ -15,7 +15,8 @@ import type { DraftEntityType } from "draft-js/lib/DraftEntityType";
 import {
   ListNestingStyles,
   blockDepthStyleFn,
-  registerCopySource,
+  onDraftEditorCopy,
+  onDraftEditorCut,
   handleDraftEditorPastedText,
   createEditorStateFromRaw,
   serialiseEditorStateToRaw,
@@ -113,15 +114,10 @@ type State = {
   readOnly: boolean,
 };
 
-/* :: import type { ElementRef } from "react"; */
-
 /**
  * Demo editor.
  */
 class DemoEditor extends Component<Props, State> {
-  /* :: editorRef: ?ElementRef<Editor>; */
-  /* :: copySource: { unregister: () => void }; */
-
   static defaultProps = {
     rawContentState: null,
   };
@@ -152,14 +148,6 @@ class DemoEditor extends Component<Props, State> {
     this.toggleEntity = this.toggleEntity.bind(this);
     this.blockRenderer = this.blockRenderer.bind(this);
     this.handlePastedText = this.handlePastedText.bind(this);
-  }
-
-  componentDidMount() {
-    this.copySource = registerCopySource(this.editorRef);
-  }
-
-  componentWillUnmount() {
-    this.copySource.unregister();
   }
 
   /* :: onChange: (nextState: EditorState) => void; */
@@ -345,9 +333,6 @@ class DemoEditor extends Component<Props, State> {
             </button>
           </div>
           <Editor
-            ref={(ref) => {
-              this.editorRef = ref;
-            }}
             editorState={editorState}
             readOnly={readOnly}
             onChange={this.onChange}
@@ -355,6 +340,8 @@ class DemoEditor extends Component<Props, State> {
             blockRendererFn={this.blockRenderer}
             blockStyleFn={blockDepthStyleFn}
             keyBindingFn={this.keyBindingFn}
+            onCopy={onDraftEditorCopy}
+            onCut={onDraftEditorCut}
             handlePastedText={this.handlePastedText}
           />
         </SentryBoundary>

--- a/src/demo/components/DemoEditor.test.js
+++ b/src/demo/components/DemoEditor.test.js
@@ -24,15 +24,6 @@ describe("DemoEditor", () => {
     ).toMatchSnapshot();
   });
 
-  it("componentWillUnmount", () => {
-    const wrapper = mount(<DemoEditor extended={false} />);
-    const copySource = wrapper.instance().copySource;
-    jest.spyOn(copySource, "unregister");
-    expect(copySource).not.toBeNull();
-    wrapper.unmount();
-    expect(copySource.unregister).toHaveBeenCalled();
-  });
-
   describe("#extended", () => {
     it("works", () => {
       expect(
@@ -127,19 +118,21 @@ describe("DemoEditor", () => {
     });
 
     it("no entity", () => {
-      window.sessionStorage.getItem = jest.fn(() =>
-        JSON.stringify({
-          entityMap: {},
-          blocks: [
-            {
-              type: "atomic",
-              text: " ",
-              entityRanges: [],
-            },
-          ],
-        }),
-      );
-      const editable = mount(<DemoEditor extended={true} />)
+      const editable = mount(
+        <DemoEditor
+          rawContentState={{
+            entityMap: {},
+            blocks: [
+              {
+                type: "atomic",
+                text: " ",
+                entityRanges: [],
+              },
+            ],
+          }}
+          extended={true}
+        />,
+      )
         .instance()
         .blockRenderer({
           getType: () => "atomic",

--- a/src/lib/api/copypaste.test.js
+++ b/src/lib/api/copypaste.test.js
@@ -1,6 +1,8 @@
 import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
 import {
   registerCopySource,
+  onDraftEditorCopy,
+  onDraftEditorCut,
   handleDraftEditorPastedText,
   getDraftEditorPastedContent,
 } from "./copypaste";
@@ -11,11 +13,16 @@ jest.mock("draft-js/lib/getContentStateFragment", () => (content) =>
   content.getBlockMap(),
 );
 
+jest.mock("draft-js/lib/editOnCopy", () => jest.fn(() => {}));
+jest.mock("draft-js/lib/editOnCut", () => jest.fn(() => {}));
+
 jest.mock("draft-js-10/lib/generateRandomKey", () => () => "a");
 jest.mock("draft-js-10/lib/getDraftEditorSelection", () => () => ({}));
 jest.mock("draft-js-10/lib/getContentStateFragment", () => (content) =>
   content.getBlockMap(),
 );
+jest.mock("draft-js-10/lib/editOnCopy", () => jest.fn(() => {}));
+jest.mock("draft-js-10/lib/editOnCut", () => jest.fn(() => {}));
 
 const dispatchEvent = (editor, type, setData) => {
   const event = Object.assign(new Event(type), {
@@ -85,6 +92,22 @@ describe("copypaste", () => {
       window.getSelection = getSelection();
       dispatchEvent(editor, "cut");
       expect(window.getSelection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onDraftEditorCopy", () => {
+    it("calls editOnCopy", () => {
+      const editor = document.createElement("div");
+      window.getSelection = getSelection();
+      onDraftEditorCopy(editor, dispatchEvent(editor, "copy"));
+    });
+  });
+
+  describe("onDraftEditorCut", () => {
+    it("does not break", () => {
+      const editor = document.createElement("div");
+      window.getSelection = getSelection();
+      onDraftEditorCut(editor, dispatchEvent(editor, "cut"));
     });
   });
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -10,6 +10,8 @@ export {
 
 export {
   registerCopySource,
+  onDraftEditorCopy,
+  onDraftEditorCut,
   handleDraftEditorPastedText,
   getDraftEditorPastedContent,
 } from "./api/copypaste";


### PR DESCRIPTION
Those methods can be used with the new `onCopy` and `onCut` props introduced in Draft.js 0.11.0,
to replace `registerCopySource` and remove the need for an editor ref. `registerCopySource` is
still available and works the same as before, but will eventually be removed once this package
drops support for Draft.js 0.10.